### PR TITLE
Add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = ["Tim Schwenke <tim.schwenke@trallnag.com>"]
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/trallnag/prometheus-fastapi-instrumentator"
-keywords = ["instrumentation", "observability", "metrics", "prometheus", "fastapi"]
+keywords = ["prometheus", "instrumentation", "fastapi", "exporter", "metrics"]
+include = ["src/prometheus_fastapi_instrumentator/py.typed"]
 
 [tool.poetry.dependencies]
 python = ">= 3.7.0, < 4.0.0"


### PR DESCRIPTION
This allows mypy to use the present type annotations in packages using an installed prometheus-fastapi-instrumentator.