### PR TITLE
actions: Support python 3.10

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ["3.6", "3.10"]
 
     steps:
 
@@ -38,7 +38,7 @@ jobs:
     - run: bash run.sh test
 
     - uses: codecov/codecov-action@v1
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
       with:
         file: ./coverage.xml
         flags: unittests
@@ -49,21 +49,21 @@ jobs:
     # ==========================================================================
 
     - run: bash run.sh lint
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
 
     - run: bash run.sh requirements
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
 
     - run: bash run.sh format
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
 
     - run: bash run.sh docs
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
 
     # ==========================================================================
 
     - uses: EndBug/add-and-commit@v5
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == 3.10
       with:
         message: 'ci: Apply automatic changes [skip ci]'
         signoff: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - uses: Gr1N/setup-poetry@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - uses: Gr1N/setup-poetry@v4
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - uses: Gr1N/setup-poetry@v4
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - uses: Gr1N/setup-poetry@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Only relevant for CI:
 
 * Bumped lowest required Python version from `3.6.0` to `3.6.2` due to Black
   requirements.
+* Updated CI to test with Python 3.10 instead of 3.9.
 
 Only relevant for development:
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ is not found.
 
 You can always check [`pyproject.toml`](/pyproject.toml) for dependencies.
 
-* `python = "^3.6"` (tested with 3.6 and 3.9)
+* `python = "^3.6"` (tested with 3.6 and 3.10)
 * `fastapi = ">=0.38.1, <=1.0.0"` (tested with 0.38.1 and 0.61.0)
 
 ## Development


### PR DESCRIPTION
# Why
- Currently python 3.10 is not officially supported and tested
- python-version as number `3.10` is parsed as `3.1`
![image](https://user-images.githubusercontent.com/1215722/165233078-0e603b75-1110-48e9-9617-76490a57b7a5.png)

# What
- Run commit-tests with python 3.10
- Change python-version to string as `3.10` would else be parsed as `3.1`

## Additional info
- Tested build in forked-repository https://github.com/Luke31/prometheus-fastapi-instrumentator/pull/1/files#diff-191bb5b4e97db48c9d0bdb945dd00e17b53249422f60a642e9e8d73250b5913aR7 
  - Of course can't publish package because no permission to do so https://github.com/Luke31/prometheus-fastapi-instrumentator/runs/6171074586?check_suite_focus=true