### PR TITLE
🐛 Expose exceptions raised by other middlewares and app code

### DIFF
--- a/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/prometheus_fastapi_instrumentator/instrumentation.py
@@ -163,7 +163,7 @@ class PrometheusFastApiInstrumentator:
                 response = await call_next(request)
                 status = str(response.status_code)
             except Exception as e:
-                raise e from None
+                raise e
             finally:
                 if not is_excluded:
                     duration = max(default_timer() - start_time, 0)


### PR DESCRIPTION
🐛 Expose exceptions raised by other middlewares and app code

It seems the traceback for other exceptions is currently hidden. This could fix/related to: https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/108

It seems it could also be related to: https://github.com/encode/starlette/issues/1634

