### PR TITLE
feat: Allow passing a custom registry to be used instead of using the default one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
   [#76](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/76)
   and to [@HadilD](https://github.com/HadilD) for implementing it in
   [#203](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/203).
+- Allowed passing a custom registry to be used instead of using the default one.
+  This would be useful in particular when testing multiple FastAPI apps (e.g.
+  microservices) in the same tests run. Note that there are issues with the
+  current implementation in certain corner cases. Thanks to
+  [@tiangolo](https://github.com/tiangolo) for for proposing this enhancement
+  and implementing it in
+  [#153](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/153).
 
 ### Changed
 

--- a/src/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/src/prometheus_fastapi_instrumentator/instrumentation.py
@@ -180,6 +180,7 @@ class PrometheusFastApiInstrumentator:
             should_only_respect_2xx_for_highr=should_only_respect_2xx_for_highr,
             latency_highr_buckets=latency_highr_buckets,
             latency_lowr_buckets=latency_lowr_buckets,
+            registry=self.registry,
         )
         return self
 

--- a/src/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/src/prometheus_fastapi_instrumentator/instrumentation.py
@@ -110,6 +110,20 @@ class PrometheusFastApiInstrumentator:
 
         self.instrumentations: List[Callable[[metrics.Info], None]] = []
 
+        if registry:
+            self.registry = registry
+        elif "prometheus_multiproc_dir" in os.environ:
+            pmd = os.environ["prometheus_multiproc_dir"]
+            if os.path.isdir(pmd):
+                self.registry = CollectorRegistry()
+                multiprocess.MultiProcessCollector(self.registry)
+            else:
+                raise ValueError(
+                    f"Env var prometheus_multiproc_dir='{pmd}' not a directory."
+                )
+        else:
+            self.registry = REGISTRY
+
     def instrument(
         self,
         app: FastAPI,

--- a/src/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/src/prometheus_fastapi_instrumentator/instrumentation.py
@@ -5,6 +5,13 @@ from enum import Enum
 from typing import Callable, List, Optional, Union
 
 from fastapi import FastAPI
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    CollectorRegistry,
+    generate_latest,
+    multiprocess,
+)
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -28,6 +35,7 @@ class PrometheusFastApiInstrumentator:
         env_var_name: str = "ENABLE_METRICS",
         inprogress_name: str = "http_requests_inprogress",
         inprogress_labels: bool = False,
+        registry: Union[CollectorRegistry, None] = None,
     ):
         """Create a Prometheus FastAPI Instrumentator.
 
@@ -76,6 +84,11 @@ class PrometheusFastApiInstrumentator:
             inprogress_labels (bool): Should labels `method` and `handler` be
                 part of the inprogress label? Ignored unless
                 `should_instrument_requests_inprogress` is `True`. Defaults to `False`.
+
+            registry (CollectorRegistry): A custom Prometheus registry to use. If not
+                provided, the default `REGISTRY` will be used. This can be useful if
+                you need to run multiple apps at the same time, with their own
+                registries, for example during testing.
         """
 
         self.should_group_status_codes = should_group_status_codes
@@ -213,36 +226,16 @@ class PrometheusFastApiInstrumentator:
         ):
             return self
 
-        from prometheus_client import (
-            CONTENT_TYPE_LATEST,
-            REGISTRY,
-            CollectorRegistry,
-            generate_latest,
-            multiprocess,
-        )
-
-        if "prometheus_multiproc_dir" in os.environ:
-            pmd = os.environ["prometheus_multiproc_dir"]
-            if os.path.isdir(pmd):
-                registry = CollectorRegistry()
-                multiprocess.MultiProcessCollector(registry)
-            else:
-                raise ValueError(
-                    f"Env var prometheus_multiproc_dir='{pmd}' not a directory."
-                )
-        else:
-            registry = REGISTRY
-
         @app.get(endpoint, include_in_schema=include_in_schema, tags=tags, **kwargs)
         def metrics(request: Request):
             """Endpoint that serves Prometheus metrics."""
 
             if should_gzip and "gzip" in request.headers.get("Accept-Encoding", ""):
-                resp = Response(content=gzip.compress(generate_latest(registry)))
+                resp = Response(content=gzip.compress(generate_latest(self.registry)))
                 resp.headers["Content-Type"] = CONTENT_TYPE_LATEST
                 resp.headers["Content-Encoding"] = "gzip"
             else:
-                resp = Response(content=generate_latest(registry))
+                resp = Response(content=generate_latest(self.registry))
                 resp.headers["Content-Type"] = CONTENT_TYPE_LATEST
 
             return resp

--- a/src/prometheus_fastapi_instrumentator/metrics.py
+++ b/src/prometheus_fastapi_instrumentator/metrics.py
@@ -547,69 +547,81 @@ def default(
     if latency_lowr_buckets[-1] != float("inf"):
         latency_lowr_buckets = latency_lowr_buckets + (float("inf"),)
 
-    TOTAL = Counter(
-        name="http_requests_total",
-        documentation="Total number of requests by method, status and handler.",
-        labelnames=(
-            "method",
-            "status",
-            "handler",
-        ),
-        namespace=metric_namespace,
-        subsystem=metric_subsystem,
-        registry=registry,
-    )
+    registry_names = registry._get_names(registry)
 
-    IN_SIZE = Summary(
-        name="http_request_size_bytes",
-        documentation=(
-            "Content length of incoming requests by handler. "
-            "Only value of header is respected. Otherwise ignored. "
-            "No percentile calculated. "
-        ),
-        labelnames=("handler",),
-        namespace=metric_namespace,
-        subsystem=metric_subsystem,
-        registry=registry,
-    )
+    total_name = "http_requests_total"
+    if total_name not in registry_names:
+        TOTAL = Counter(
+            name=total_name,
+            documentation="Total number of requests by method, status and handler.",
+            labelnames=(
+                "method",
+                "status",
+                "handler",
+            ),
+            namespace=metric_namespace,
+            subsystem=metric_subsystem,
+            registry=registry,
+        )
 
-    OUT_SIZE = Summary(
-        name="http_response_size_bytes",
-        documentation=(
-            "Content length of outgoing responses by handler. "
-            "Only value of header is respected. Otherwise ignored. "
-            "No percentile calculated. "
-        ),
-        labelnames=("handler",),
-        namespace=metric_namespace,
-        subsystem=metric_subsystem,
-        registry=registry,
-    )
+    in_size_name = "http_request_size_bytes"
+    if in_size_name not in registry_names:
+        IN_SIZE = Summary(
+            name=in_size_name,
+            documentation=(
+                "Content length of incoming requests by handler. "
+                "Only value of header is respected. Otherwise ignored. "
+                "No percentile calculated. "
+            ),
+            labelnames=("handler",),
+            namespace=metric_namespace,
+            subsystem=metric_subsystem,
+            registry=registry,
+        )
 
-    LATENCY_HIGHR = Histogram(
-        name="http_request_duration_highr_seconds",
-        documentation=(
-            "Latency with many buckets but no API specific labels. "
-            "Made for more accurate percentile calculations. "
-        ),
-        buckets=latency_highr_buckets,
-        namespace=metric_namespace,
-        subsystem=metric_subsystem,
-        registry=registry,
-    )
+    out_size_name = "http_response_size_bytes"
+    if out_size_name not in registry_names:
+        OUT_SIZE = Summary(
+            name=out_size_name,
+            documentation=(
+                "Content length of outgoing responses by handler. "
+                "Only value of header is respected. Otherwise ignored. "
+                "No percentile calculated. "
+            ),
+            labelnames=("handler",),
+            namespace=metric_namespace,
+            subsystem=metric_subsystem,
+            registry=registry,
+        )
 
-    LATENCY_LOWR = Histogram(
-        name="http_request_duration_seconds",
-        documentation=(
-            "Latency with only few buckets by handler. "
-            "Made to be only used if aggregation by handler is important. "
-        ),
-        buckets=latency_lowr_buckets,
-        labelnames=("handler",),
-        namespace=metric_namespace,
-        subsystem=metric_subsystem,
-        registry=registry,
-    )
+    latency_highr_name = "http_request_duration_highr_seconds"
+    if latency_highr_name not in registry_names:
+        LATENCY_HIGHR = Histogram(
+            name=latency_highr_name,
+            documentation=(
+                "Latency with many buckets but no API specific labels. "
+                "Made for more accurate percentile calculations. "
+            ),
+            buckets=latency_highr_buckets,
+            namespace=metric_namespace,
+            subsystem=metric_subsystem,
+            registry=registry,
+        )
+
+    latency_lowr_name = "http_request_duration_seconds"
+    if latency_lowr_name not in registry_names:
+        LATENCY_LOWR = Histogram(
+            name=latency_lowr_name,
+            documentation=(
+                "Latency with only few buckets by handler. "
+                "Made to be only used if aggregation by handler is important. "
+            ),
+            buckets=latency_lowr_buckets,
+            labelnames=("handler",),
+            namespace=metric_namespace,
+            subsystem=metric_subsystem,
+            registry=registry,
+        )
 
     def instrumentation(info: Info) -> None:
         TOTAL.labels(info.method, info.modified_status, info.modified_handler).inc()

--- a/src/prometheus_fastapi_instrumentator/metrics.py
+++ b/src/prometheus_fastapi_instrumentator/metrics.py
@@ -12,7 +12,7 @@ from this module.
 
 from typing import Callable, Optional, Tuple
 
-from prometheus_client import Counter, Histogram, Summary
+from prometheus_client import REGISTRY, CollectorRegistry, Counter, Histogram, Summary
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -496,6 +496,7 @@ def default(
         60,
     ),
     latency_lowr_buckets: tuple = (0.1, 0.5, 1),
+    registry: CollectorRegistry = REGISTRY,
 ) -> Callable[[Info], None]:
     """Contains multiple metrics to cover multiple things.
 
@@ -556,6 +557,7 @@ def default(
         ),
         namespace=metric_namespace,
         subsystem=metric_subsystem,
+        registry=registry,
     )
 
     IN_SIZE = Summary(
@@ -568,6 +570,7 @@ def default(
         labelnames=("handler",),
         namespace=metric_namespace,
         subsystem=metric_subsystem,
+        registry=registry,
     )
 
     OUT_SIZE = Summary(
@@ -580,6 +583,7 @@ def default(
         labelnames=("handler",),
         namespace=metric_namespace,
         subsystem=metric_subsystem,
+        registry=registry,
     )
 
     LATENCY_HIGHR = Histogram(
@@ -591,6 +595,7 @@ def default(
         buckets=latency_highr_buckets,
         namespace=metric_namespace,
         subsystem=metric_subsystem,
+        registry=registry,
     )
 
     LATENCY_LOWR = Histogram(
@@ -603,6 +608,7 @@ def default(
         labelnames=("handler",),
         namespace=metric_namespace,
         subsystem=metric_subsystem,
+        registry=registry,
     )
 
     def instrumentation(info: Info) -> None:

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from timeit import default_timer
 from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple
 
-from prometheus_client import Gauge
+from prometheus_client import REGISTRY, CollectorRegistry, Gauge
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import Response
@@ -60,6 +60,7 @@ class PrometheusInstrumentatorMiddleware:
             60,
         ),
         latency_lowr_buckets: tuple = (0.1, 0.5, 1),
+        registry: CollectorRegistry = REGISTRY,
     ) -> None:
         self.app = app
 
@@ -74,6 +75,7 @@ class PrometheusInstrumentatorMiddleware:
         self.env_var_name = env_var_name
         self.inprogress_name = inprogress_name
         self.inprogress_labels = inprogress_labels
+        self.registry = registry
 
         self.excluded_handlers = [re.compile(path) for path in excluded_handlers]
         self.instrumentations = instrumentations or [
@@ -83,6 +85,7 @@ class PrometheusInstrumentatorMiddleware:
                 should_only_respect_2xx_for_highr=should_only_respect_2xx_for_highr,
                 latency_highr_buckets=latency_highr_buckets,
                 latency_lowr_buckets=latency_lowr_buckets,
+                registry=self.registry,
             )
         ]
 

--- a/tests/test_instrumentator_multiple_apps.py
+++ b/tests/test_instrumentator_multiple_apps.py
@@ -33,13 +33,43 @@ def get_response(client: TestClient, path: str) -> TestClientResponse:
 # Tests
 
 
-def test_expose_defaults():
+def test_expose_defaults_custom_registry():
     app1 = create_app()
     app2 = create_app()
     registry1 = CollectorRegistry(auto_describe=True)
     registry2 = CollectorRegistry(auto_describe=True)
     Instrumentator(registry=registry1).instrument(app1).expose(app1)
     Instrumentator(registry=registry2).instrument(app2).expose(app2)
+
+    # Add middlewares after adding the instrumentator, this triggers another
+    # app.build_middleware_stack(), which creates the middleware again, but it will use
+    # the same Prometheus registry again, which could try to create the same metrics
+    # again causing duplication errors
+    @app1.middleware("http")
+    @app2.middleware("http")
+    async def no_op_middleware(request, call_next):
+        response = await call_next(request)
+        return response
+
+    client1 = TestClient(app1)
+    client2 = TestClient(app2)
+
+    get_response(client1, "/")
+    get_response(client2, "/")
+
+    response1 = get_response(client1, "/metrics")
+    response2 = get_response(client2, "/metrics")
+    assert response1.status_code == 200
+    assert b"http_request" in response1.content
+    assert response2.status_code == 200
+    assert b"http_request" in response2.content
+
+
+def test_expose_defaults():
+    app1 = create_app()
+    app2 = create_app()
+    Instrumentator().instrument(app1).expose(app1)
+    Instrumentator().instrument(app2).expose(app2)
 
     # Add middlewares after adding the instrumentator, this triggers another
     # app.build_middleware_stack(), which creates the middleware again, but it will use

--- a/tests/test_instrumentator_multiple_apps.py
+++ b/tests/test_instrumentator_multiple_apps.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from prometheus_client import CollectorRegistry
+from requests import Response as TestClientResponse
+from starlette.testclient import TestClient
+
+from prometheus_fastapi_instrumentator import Instrumentator
+
+# ------------------------------------------------------------------------------
+# Setup
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/")
+    def read_root():
+        return "Hello World!"
+
+    return app
+
+
+def get_response(client: TestClient, path: str) -> TestClientResponse:
+    response = client.get(path)
+
+    print(f"\nResponse  path='{path}' status='{response.status_code}':\n")
+    for line in response.content.split(b"\n"):
+        print(line.decode())
+
+    return response
+
+
+# ------------------------------------------------------------------------------
+# Tests
+
+
+def test_expose_defaults():
+    app1 = create_app()
+    app2 = create_app()
+    registry1 = CollectorRegistry(auto_describe=True)
+    registry2 = CollectorRegistry(auto_describe=True)
+    Instrumentator(registry=registry1).instrument(app1).expose(app1)
+    Instrumentator(registry=registry2).instrument(app2).expose(app2)
+    client1 = TestClient(app1)
+    client2 = TestClient(app2)
+
+    get_response(client1, "/")
+    get_response(client2, "/")
+
+    response1 = get_response(client1, "/metrics")
+    response2 = get_response(client2, "/metrics")
+    assert response1.status_code == 200
+    assert b"http_request" in response1.content
+    assert response2.status_code == 200
+    assert b"http_request" in response2.content


### PR DESCRIPTION
✨ Allow passing a custom registry to be used instead of using the default one.

This would be useful in particular when testing multiple FastAPI apps (e.g. microservices) in the same tests run.

This is also related to https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/80

**Note**: I'm still having issues with this in different corner cases. The way that the underlying Prometheus Client for Python works is quite weird. It errors out if a metric is duplicated, but there's no way to check if a new metric will create that error or not. And a try block would have to be very generic catching all `ValueError`s. I'm still not sure what's the best way to handle this.