### PR TITLE
Remove print statement from middleware

### DIFF
--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -77,7 +77,6 @@ class PrometheusInstrumentatorMiddleware:
 
         handler, is_templated = self._get_handler(request)
         is_excluded = self._is_handler_excluded(handler, is_templated)
-        print(is_excluded)
         handler = (
             "none" if not is_templated and self.should_group_untemplated else handler
         )


### PR DESCRIPTION
As mentioned in issue #156 and #151 the middleware prints at sometime.
I simply removed the print statement.