### PR TITLE
removes handler_excluded print

### DIFF
--- a/prometheus_fastapi_instrumentator/middleware.py
+++ b/prometheus_fastapi_instrumentator/middleware.py
@@ -77,7 +77,6 @@ class PrometheusInstrumentatorMiddleware:
 
         handler, is_templated = self._get_handler(request)
         is_excluded = self._is_handler_excluded(handler, is_templated)
-        print(is_excluded)
         handler = (
             "none" if not is_templated and self.should_group_untemplated else handler
         )


### PR DESCRIPTION
Every request in the api is printed either True or False according to handler_excluded, this commit removes print

print:
![image](https://user-images.githubusercontent.com/864013/181508980-1d9357cb-d6d4-4ecc-a99a-7f4f067a2a37.png)
