### PR TITLE
fix: Use value if HTTP status is enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
   code being used from a repo licensed under BSD-3-Clause (see the "Added"
   section). The default ISC License and the BSD-3-Clause License are permissive.
 
+### Fixed
+
+- Fixed status code in metric being "Hxx" when `http.HTTPStatus` enumeration is
+  used in combination with grouping of status codes. Thanks to
+  [@Leem0sh](https://github.com/Leem0sh) and others for raising the issue in
+  [#190](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/190).
+  Thanks to [@nikstuckenbrock](https://github.com/nikstuckenbrock) and
+  [@blag](https://github.com/blag) for fixing it in
+  [#192](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/192).
+
 ## [5.9.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v5.9.0...v5.9.1) / 2022-08-23
 
 ### Fixed

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -142,10 +142,7 @@ class PrometheusInstrumentatorMiddleware:
         except Exception as exc:
             raise exc
         finally:
-            if type(status_code) == HTTPStatus:
-                status = str(status_code.value)
-            else:
-                status = str(status_code)
+            status = str(status_code.value) if isinstance(status_code, HTTPStatus) else str(status_code)
 
             if not is_excluded:
                 duration = max(default_timer() - start_time, 0)

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from http import HTTPStatus
 from timeit import default_timer
 from typing import TYPE_CHECKING, Callable, Optional, Sequence, Tuple
 
@@ -141,7 +142,10 @@ class PrometheusInstrumentatorMiddleware:
         except Exception as exc:
             raise exc
         finally:
-            status = str(status_code)
+            if type(status_code) == HTTPStatus:
+                status = str(status_code.value)
+            else:
+                status = str(status_code)
 
             if not is_excluded:
                 duration = max(default_timer() - start_time, 0)

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -142,7 +142,11 @@ class PrometheusInstrumentatorMiddleware:
         except Exception as exc:
             raise exc
         finally:
-            status = str(status_code.value) if isinstance(status_code, HTTPStatus) else str(status_code)
+            status = (
+                str(status_code.value)
+                if isinstance(status_code, HTTPStatus)
+                else str(status_code)
+            )
 
             if not is_excluded:
                 duration = max(default_timer() - start_time, 0)

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,8 +1,8 @@
 import asyncio
 import os
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 
-from http import HTTPStatus
 from fastapi import FastAPI, HTTPException
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 from requests import Response as TestClientResponse
@@ -55,7 +55,9 @@ def create_app() -> FastAPI:
 
     @app.get("/always_error_httpstatus_enum")
     def read_always_error_httpstatus_enum():
-        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Not really an error")
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Not really an error"
+        )
 
     @app.get("/ignore")
     def read_ignore():

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from typing import Any, Dict, Optional
 
+from http import HTTPStatus
 from fastapi import FastAPI, HTTPException
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 from requests import Response as TestClientResponse
@@ -51,6 +52,10 @@ def create_app() -> FastAPI:
     @app.get("/always_error")
     def read_always_error():
         raise HTTPException(status_code=404, detail="Not really error")
+
+    @app.get("/always_error_httpstatus_enum")
+    def read_always_error_httpstatus_enum():
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Not really an error")
 
     @app.get("/ignore")
     def read_ignore():
@@ -144,6 +149,10 @@ def test_app():
     response = get_response(client, "/always_error")
     assert response.status_code == 404
     assert b"Not really error" in response.content
+
+    response = get_response(client, "/always_error_httpstatus_enum")
+    assert response.status_code == 404
+    assert b"Not really an error" in response.content
 
     response = get_response(client, "/items/678?q=43243")
     assert response.status_code == 200
@@ -270,6 +279,20 @@ def test_grouped_status_codes():
     assert_request_count(1)
     assert b'status="2xx"' in response.content
     assert b'status="200"' not in response.content
+
+
+def test_grouped_status_codes_with_enumeration():
+    app = create_app()
+    Instrumentator(excluded_handlers=["/metrics"]).add(metrics.latency()).instrument(app)
+    expose_metrics(app)
+    client = TestClient(app)
+
+    get_response(client, "/always_error_httpstatus_enum")
+
+    response = get_response(client, "/metrics")
+    assert_is_not_multiprocess(response)
+    assert b'status="4xx"' in response.content
+    assert b'status="H00"' not in response.content
 
 
 def test_ungrouped_status_codes():


### PR DESCRIPTION
As mentioned in #190 the instrumentator has a bug when using the `http.HTTPStatus` enumeration for a status code response. If fixed this bug and added some tests to verify.

I would be very thankful if you would add the `HACKTOBERFEST-ACCEPTED` to this pull request.