### PR TITLE
feat: Add namespace and subsystem configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
   [@LordGaav](https://github.com/LordGaav) for proposing this enhancement and
   implementing it in
   [#208](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/208).
+- Added optional parameters `metric_namespace` and `metric_subsystem` to
+  `instrument()` method to configure namespace and subsystem for all metric
+  names. Check the [`README.md`](README.md#specify-namespace-and-subsystem) for
+  more information. Thanks to [@phbernardes](https://github.com/phbernardes) for
+  proposing this enhancement and implementing it in
+  [#193](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/193).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ well.
     - [Adding metrics](#adding-metrics)
     - [Creating new metrics](#creating-new-metrics)
     - [Perform instrumentation](#perform-instrumentation)
+    - [Specify namespace and subsystem](#specify-namespace-and-subsystem)
     - [Exposing endpoint](#exposing-endpoint)
   - [Prerequesites](#prerequesites)
   - [Contributing](#contributing)
@@ -269,7 +270,7 @@ async def startup():
 
 Then your metrics will contain the namespace and subsystem in the metric name.
 
-```bash
+```sh
 # TYPE myproject_myservice_http_request_duration_highr_seconds histogram
 myproject_myservice_http_request_duration_highr_seconds_bucket{le="0.01"} 0.0
 ```

--- a/README.md
+++ b/README.md
@@ -254,6 +254,26 @@ Notice that this will do nothing if `should_respect_env_var` has been set during
 construction of the instrumentator object and the respective env var is not
 found.
 
+### Specify namespace and subsystem
+
+You can specify the namespace and subsystem of the metrics by passing them in
+the instrument method.
+
+```python
+from prometheus_fastapi_instrumentator import Instrumentator
+
+@app.on_event("startup")
+async def startup():
+    Instrumentator().instrument(app, metric_namespace='myproject', metric_subsystem='myservice').expose(app)
+```
+
+Then your metrics will contain the namespace and subsystem in the metric name.
+
+```bash
+# TYPE myproject_myservice_http_request_duration_highr_seconds histogram
+myproject_myservice_http_request_duration_highr_seconds_bucket{le="0.01"} 0.0
+```
+
 ### Exposing endpoint
 
 To expose an endpoint for the metrics either follow

--- a/src/prometheus_fastapi_instrumentator/instrumentation.py
+++ b/src/prometheus_fastapi_instrumentator/instrumentation.py
@@ -97,7 +97,37 @@ class PrometheusFastApiInstrumentator:
 
         self.instrumentations: List[Callable[[metrics.Info], None]] = []
 
-    def instrument(self, app: FastAPI):
+    def instrument(
+        self,
+        app: FastAPI,
+        metric_namespace: str = "",
+        metric_subsystem: str = "",
+        should_only_respect_2xx_for_highr: bool = False,
+        latency_highr_buckets: tuple = (
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1,
+            1.5,
+            2,
+            2.5,
+            3,
+            3.5,
+            4,
+            4.5,
+            5,
+            7.5,
+            10,
+            30,
+            60,
+        ),
+        latency_lowr_buckets: tuple = (0.1, 0.5, 1),
+    ):
         """Performs the instrumentation by adding middleware.
 
         The middleware iterates through all `instrumentations` and executes them.
@@ -132,6 +162,11 @@ class PrometheusFastApiInstrumentator:
             inprogress_labels=self.inprogress_labels,
             instrumentations=self.instrumentations,
             excluded_handlers=self.excluded_handlers,
+            metric_namespace=metric_namespace,
+            metric_subsystem=metric_subsystem,
+            should_only_respect_2xx_for_highr=should_only_respect_2xx_for_highr,
+            latency_highr_buckets=latency_highr_buckets,
+            latency_lowr_buckets=latency_lowr_buckets,
         )
         return self
 

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -32,6 +32,33 @@ class PrometheusInstrumentatorMiddleware:
         inprogress_name: str = "http_requests_inprogress",
         inprogress_labels: bool = False,
         instrumentations: Sequence[Callable[[metrics.Info], None]] = (),
+        metric_namespace: str = "",
+        metric_subsystem: str = "",
+        should_only_respect_2xx_for_highr: bool = False,
+        latency_highr_buckets: tuple = (
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1,
+            1.5,
+            2,
+            2.5,
+            3,
+            3.5,
+            4,
+            4.5,
+            5,
+            7.5,
+            10,
+            30,
+            60,
+        ),
+        latency_lowr_buckets: tuple = (0.1, 0.5, 1),
     ) -> None:
         self.app = app
 
@@ -48,7 +75,15 @@ class PrometheusInstrumentatorMiddleware:
         self.inprogress_labels = inprogress_labels
 
         self.excluded_handlers = [re.compile(path) for path in excluded_handlers]
-        self.instrumentations = instrumentations or [metrics.default()]
+        self.instrumentations = instrumentations or [
+            metrics.default(
+                metric_namespace=metric_namespace,
+                metric_subsystem=metric_subsystem,
+                should_only_respect_2xx_for_highr=should_only_respect_2xx_for_highr,
+                latency_highr_buckets=latency_highr_buckets,
+                latency_lowr_buckets=latency_lowr_buckets,
+            )
+        ]
 
         self.inprogress: Optional[Gauge] = None
         if self.should_instrument_requests_inprogress:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -554,3 +554,20 @@ def test_requests_no_labels():
         )
         == 2
     )
+
+
+def test_request_custom_namespace():
+    app = create_app()
+    Instrumentator(excluded_handlers=["/metrics"]).instrument(
+        app, metric_namespace="namespace", metric_subsystem="example"
+    ).expose(app)
+    client = TestClient(app)
+
+    client.get("/")
+
+    response = get_response(client, "/metrics")
+
+    assert (
+        b"namespace_example_http_request_duration_highr_seconds_bucket"
+        in response.content
+    )


### PR DESCRIPTION
* Accept namespace and subsystem parameters in instrument definition.

Hi, I open this PR to be able to set the namespace and subsystem during instrumentation initialisation.

Having this parameter is important for projects where several metrics endpoints are fetched and metrics are squashed together.

This will allow us to have the same behaviour as [prometheus-flask-instrumentator](https://github.com/trallnag/prometheus-flask-instrumentator) (when using the defaults_prefix argument of PrometheusMetrics).

Thank you.