### PR TITLE
feat: Add smart handling of mounted apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ## Unreleased
 
-Nothing.
+### Added
+
+- Added smart handling of mounted apps. Previously the URL handler logic did not
+  handle mounted apps and always returned the prefix in that case. This is based
+  on code from
+  [elastic/apm-agent-python](https://github.com/elastic/apm-agent-python)
+  licensed under the permissive BSD-3-Clause License. Thanks to
+  [@LordGaav](https://github.com/LordGaav) for proposing this enhancement and
+  implementing it in
+  [#208](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/208).
+
+### Changed
+
+- Licensed part of the project under the BSD-3-Clause License. This is due to
+  code being used from a repo licensed under BSD-3-Clause (see the "Added"
+  section). The default ISC License and the BSD-3-Clause License are permissive.
 
 ## [5.9.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v5.9.0...v5.9.1) / 2022-08-23
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ well.
     - [Exposing endpoint](#exposing-endpoint)
   - [Prerequesites](#prerequesites)
   - [Contributing](#contributing)
+  - [Licensing](#licensing)
 
 <!--TOC-->
 
@@ -281,5 +282,23 @@ You can always check [`pyproject.toml`](/pyproject.toml) for dependencies.
 ## Contributing
 
 Please refer to [`CONTRIBUTING.md`](CONTRIBUTING).
+
+## Licensing
+
+The default license for this project is the
+[ISC License](https://choosealicense.com/licenses/isc). A permissive license
+functionally equivalent to the BSD 2-Clause and MIT licenses, removing some
+language that is no longer necessary. See [`LICENSE`](LICENSE) for the license
+text.
+
+The [BSD 3-Clause License](https://choosealicense.com/licenses/bsd-3-clause) is
+used as the license for the
+[`routing`](src/prometheus_fastapi_instrumentator/routing.py) module. This is
+due to it containing code from
+[elastic/apm-agent-python](https://github.com/elastic/apm-agent-python). BSD
+3-Clause is permissive license similar to the BSD 2-Clause License, but with a
+3rd clause that prohibits others from using the name of the copyright holder or
+its contributors to promote derived products without written consent. The
+license text is included in the module itself.
 
 [project-status-issue]: https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/140

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -8,54 +8,11 @@ from prometheus_client import Gauge
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Match, Mount
 
-from prometheus_fastapi_instrumentator import metrics
+from prometheus_fastapi_instrumentator import metrics, routing
 
 if TYPE_CHECKING:
     from asgiref.typing import ASGISendEvent
-
-
-def _get_route_name(scope, routes, route_name=None) -> Optional[str]:
-    for route in routes:
-        match, child_scope = route.matches(scope)
-        if match == Match.FULL:
-            route_name = route.path
-            child_scope = {**scope, **child_scope}
-            if isinstance(route, Mount) and route.routes:
-                child_route_name = _get_route_name(child_scope, route.routes, route_name)
-                if child_route_name is None:
-                    route_name = None
-                else:
-                    route_name += child_route_name
-            return route_name
-        elif match == Match.PARTIAL and route_name is None:
-            route_name = route.path
-    return None
-
-
-def get_route_name(request: Request) -> Optional[str]:
-    app = request.app
-    scope = request.scope
-    routes = app.routes
-    route_name = _get_route_name(scope, routes)
-
-    # Starlette magically redirects requests if the path matches a route name with a trailing slash
-    # appended or removed. To not spam the transaction names list, we do the same here and put these
-    # redirects all in the same "redirect trailing slashes" transaction name
-    if not route_name and app.router.redirect_slashes and scope["path"] != "/":
-        redirect_scope = dict(scope)
-        if scope["path"].endswith("/"):
-            redirect_scope["path"] = scope["path"][:-1]
-            trim = True
-        else:
-            redirect_scope["path"] = scope["path"] + "/"
-            trim = False
-
-        route_name = _get_route_name(redirect_scope, routes)
-        if route_name is not None:
-            route_name = route_name + "/" if trim else route_name[:-1]
-    return route_name
 
 
 class PrometheusInstrumentatorMiddleware:
@@ -184,7 +141,7 @@ class PrometheusInstrumentatorMiddleware:
                 template or if no template the path. Second element tells you
                 if the path is templated or not.
         """
-        route_name = get_route_name(request)
+        route_name = routing.get_route_name(request)
         return route_name or request.url.path, True if route_name else False
 
     def _is_handler_excluded(self, handler: str, is_templated: bool) -> bool:

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -1,0 +1,90 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
+# Copyright (c) 2019, Elasticsearch BV
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+
+"""Helper module for routing.
+
+The two functions in this module are licensed under the BSD 3-Clause License
+instead of the ISC License like the rest of the project. Therefore the code
+is contained in a dedicated module.
+
+Based on code from [elastic/apm-agent-python](https://github.com/elastic/apm-agent-python/blob/527f62c0c50842f94ef90fda079853372539319a/elasticapm/contrib/starlette/__init__.py).
+"""
+
+from typing import Optional
+
+from starlette.requests import Request
+from starlette.routing import Match, Mount
+
+
+def _get_route_name(scope, routes, route_name=None) -> Optional[str]:
+    """Gets route name for given scope taking mounts into account."""
+
+    for route in routes:
+        match, child_scope = route.matches(scope)
+        if match == Match.FULL:
+            route_name = route.path
+            child_scope = {**scope, **child_scope}
+            if isinstance(route, Mount) and route.routes:
+                child_route_name = _get_route_name(child_scope, route.routes, route_name)
+                if child_route_name is None:
+                    route_name = None
+                else:
+                    route_name += child_route_name
+            return route_name
+        elif match == Match.PARTIAL and route_name is None:
+            route_name = route.path
+    return None
+
+
+def get_route_name(request: Request) -> Optional[str]:
+    """Gets route name for given request taking mounts into account."""
+
+    app = request.app
+    scope = request.scope
+    routes = app.routes
+    route_name = _get_route_name(scope, routes)
+
+    # Starlette magically redirects requests if the path matches a route name
+    # with a trailing slash appended or removed. To not spam the transaction
+    # names list, we do the same here and put these redirects all in the
+    # same "redirect trailing slashes" transaction name.
+    if not route_name and app.router.redirect_slashes and scope["path"] != "/":
+        redirect_scope = dict(scope)
+        if scope["path"].endswith("/"):
+            redirect_scope["path"] = scope["path"][:-1]
+            trim = True
+        else:
+            redirect_scope["path"] = scope["path"] + "/"
+            trim = False
+
+        route_name = _get_route_name(redirect_scope, routes)
+        if route_name is not None:
+            route_name = route_name + "/" if trim else route_name[:-1]
+    return route_name


### PR DESCRIPTION
The old one did not handle mounted apps and always returned the prefix in that case.

Elastic APM code was found at https://github.com/elastic/apm-agent-python/blob/527f62c0c50842f94ef90fda079853372539319a/elasticapm/contrib/starlette/__init__.py#L242 and is licensed under BSD-3 Clause.