### PR TITLE
chore: Deprecate lower-case prometheus_multiproc_dir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,13 @@ jobs:
       - name: Run tests with Pytest
         run: poetry run pytest --cov-report=term-missing --cov-report=xml --cov=src
 
+      - name: Run multi process tests with Pytest
+        run: |
+          rm -rf $PROMETHEUS_MULTIPROC_DIR
+          mkdir -p $PROMETHEUS_MULTIPROC_DIR
+          poetry run pytest -k test_multiprocess \
+            --cov-append --cov-report=term-missing --cov-report=xml --cov=src
+
       - name: Upload coverage to Codecov
         if: strategy.job-index == 0
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Run multi process tests with Pytest
         run: |
+          export PROMETHEUS_MULTIPROC_DIR=/tmp/one-two-three
           rm -rf $PROMETHEUS_MULTIPROC_DIR
           mkdir -p $PROMETHEUS_MULTIPROC_DIR
           poetry run pytest -k test_multiprocess \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
   [@blag](https://github.com/blag) for fixing it in
   [#192](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/192).
 
+### Deprecated
+
+- Deprecated environment variable `prometheus_multiproc_dir` and replaced it
+  with `PROMETHEUS_MULTIPROC_DIR`. This matches the behavior of the Prometheus
+  Python client library. This fixes
+  [#89](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/89)
+  and
+  [#50](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/50).
+  Thanks to all the people who brought this up. Thanks to
+  [@michaelusner](https://github.com/michaelusner) for implementing the
+  deprecation in
+  [#42](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/42) /
+  [#217](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/217).
+
 ## [5.9.1](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v5.9.0...v5.9.1) / 2022-08-23
 
 ### Fixed

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -23,3 +23,13 @@ tasks:
     desc: Run tests.
     cmds:
       - poetry run pytest --cov-report=term-missing --cov-report=xml --cov=src
+
+  test-mp:
+    desc: Run multi process tests.
+    cmds:
+      - rm -rf $PROMETHEUS_MULTIPROC_DIR
+      - mkdir -p $PROMETHEUS_MULTIPROC_DIR
+      - poetry run pytest -k test_multiprocess
+        --cov-append --cov-report=term-missing --cov-report=xml --cov=src
+    env:
+      PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus-fastapi-instrumentator/multiproc

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -3,6 +3,7 @@ import os
 from http import HTTPStatus
 from typing import Any, Dict, Optional
 
+import pytest
 from fastapi import FastAPI, HTTPException
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 from requests import Response as TestClientResponse
@@ -79,17 +80,17 @@ def create_app() -> FastAPI:
 
 
 def expose_metrics(app: FastAPI) -> None:
-    if "prometheus_multiproc_dir" in os.environ:
-        pmd = os.environ["prometheus_multiproc_dir"]
-        print(f"Env var prometheus_multiproc_dir='{pmd}' detected.")
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        pmd = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+        print(f"Env var PROMETHEUS_MULTIPROC_DIR='{pmd}' detected.")
         if os.path.isdir(pmd):
-            print(f"Env var prometheus_multiproc_dir='{pmd}' is a dir.")
+            print(f"Env var PROMETHEUS_MULTIPROC_DIR='{pmd}' is a dir.")
             from prometheus_client import CollectorRegistry, multiprocess
 
             registry = CollectorRegistry()
             multiprocess.MultiProcessCollector(registry)
         else:
-            raise ValueError(f"Env var prometheus_multiproc_dir='{pmd}' not a directory.")
+            raise ValueError(f"Env var PROMETHEUS_MULTIPROC_DIR='{pmd}' not a directory.")
     else:
         registry = REGISTRY
 
@@ -544,3 +545,118 @@ def test_rounding():
     entropy = calc_entropy(str(result).split(".")[1][4:])
 
     assert entropy < 10
+
+
+# ==============================================================================
+# Test with multiprocess reg.
+
+
+def is_prometheus_multiproc_set():
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        pmd = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+        if os.path.isdir(pmd):
+            return True
+    else:
+        return False
+
+
+# The environment variable MUST be set before anything regarding Prometheus is
+# imported. That is why we cannot simply use `tempfile` or the fixtures
+# provided by pytest. Test with:
+#       mkdir -p /tmp/test_multiproc;
+#       export PROMETHEUS_MULTIPROC_DIR=/tmp/test_multiproc;
+#       pytest -k test_multiprocess_reg;
+#       rm -rf /tmp/test_multiproc;
+#       unset PROMETHEUS_MULTIPROC_DIR
+
+
+@pytest.mark.skipif(
+    is_prometheus_multiproc_set() is False,
+    reason="Environment variable must be set before starting Python process.",
+)
+def test_multiprocess_reg():
+    app = create_app()
+    Instrumentator(excluded_handlers=["/metrics"]).add(
+        metrics.latency(
+            buckets=(
+                1,
+                2,
+                3,
+            )
+        )
+    ).instrument(app).expose(app)
+    client = TestClient(app)
+
+    get_response(client, "/")
+
+    response = get_response(client, "/metrics")
+    assert response.status_code == 200
+    assert b"Multiprocess" in response.content
+    assert b"# HELP process_cpu_seconds_total" not in response.content
+    assert b"http_request_duration_seconds" in response.content
+
+
+@pytest.mark.skipif(is_prometheus_multiproc_set() is True, reason="Will never work.")
+def test_multiprocess_reg_is_not(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    app = create_app()
+    Instrumentator(excluded_handlers=["/metrics"]).add(metrics.latency()).instrument(
+        app
+    ).expose(app)
+
+    client = TestClient(app)
+
+    get_response(client, "/")
+
+    response = get_response(client, "/metrics")
+    assert response.status_code == 200
+    assert b"" == response.content
+
+
+@pytest.mark.skipif(
+    is_prometheus_multiproc_set() is True, reason="Just test handling of env detection."
+)
+def test_multiprocess_env_folder(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", "DOES/NOT/EXIST")
+
+    app = create_app()
+    with pytest.raises(Exception):
+        Instrumentator(buckets=(1, 2, 3,)).add(
+            metrics.latency()
+        ).instrument(app)
+
+
+# ------------------------------------------------------------------------------
+# Test inprogress.
+
+
+@pytest.mark.skipif(
+    is_prometheus_multiproc_set() is False,
+    reason="Environment variable must be set before starting Python process.",
+)
+def test_multiprocess_inprogress():
+    app = create_app()
+    Instrumentator(
+        should_instrument_requests_inprogress=True, inprogress_labels=True
+    ).instrument(app).expose(app)
+    client = TestClient(app)
+
+    async def main():
+        loop = asyncio.get_event_loop()
+        futures = [
+            loop.run_in_executor(None, get_response, client, "/sleep?seconds=0.1")
+            for i in range(5)
+        ]
+        for response in await asyncio.gather(*futures):
+            assert response.status_code == 200
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+
+    response = get_response(client, "/metrics")
+    assert response.status_code == 200
+    assert b"Multiprocess" in response.content
+    assert b"# HELP process_cpu_seconds_total" not in response.content
+    assert b"http_request_duration_seconds" in response.content
+    assert b'http_requests_inprogress{handler="/sleep",method="GET"}' in response.content


### PR DESCRIPTION
Related to [#42](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/42). I pushed the changes from that PR to a new branch within this repository. Why? The fork has been deleted and I was not able to figure out how to update the PR otherwise.
