### PR TITLE
fix: Remove unnecessary body aggregation

### DIFF
--- a/src/prometheus_fastapi_instrumentator/__init__.py
+++ b/src/prometheus_fastapi_instrumentator/__init__.py
@@ -1,5 +1,5 @@
 from .instrumentation import PrometheusFastApiInstrumentator
 
-__version__ = "5.11.1"
+__version__ = "5.12.0"
 
 Instrumentator = PrometheusFastApiInstrumentator

--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -137,18 +137,12 @@ class PrometheusInstrumentatorMiddleware:
 
         status_code = 500
         headers = []
-        body = b""
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
                 nonlocal status_code, headers
                 headers = message["headers"]
                 status_code = message["status"]
-            elif message["type"] == "http.response.body" and message.get(
-                "more_body", False
-            ):
-                nonlocal body
-                body += message["body"]
             await send(message)
 
         try:
@@ -175,7 +169,7 @@ class PrometheusInstrumentatorMiddleware:
                     status = status[0] + "xx"
 
                 response = Response(
-                    content=body, headers=Headers(raw=headers), status_code=status_code
+                    content=b"", headers=Headers(raw=headers), status_code=status_code
                 )
 
                 info = metrics.Info(


### PR DESCRIPTION
Collection of body content doesn't matter much when the response size is under a few megs, but when a response is a [FileResponse](https://www.starlette.io/responses/#fileresponse) beyond a couple hundred megs, it really starts to matter.

Considering response.body isn't used in any metrics in metrics.py, I'd suggest removing its collection altogether.