### PR TITLE
feat: Relax type of get_route_name argument to HttpConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ## Unreleased
 
+### Changed
+
+- Relaxed type of `get_route_name` argument to `HTTPConnection`. This allows
+  developers to use the `get_route_name` function for getting the name of
+  websocket routes as well. Thanks to [@pajowu](https://github.com/pajowu) for
+  proposing and implementing this change in
+  [#276](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/276).
+
 ### Removed
 
 - **BREAKING:** Dropped support for Python 3.7 which is has reached end-of-life.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ## Unreleased
 
-### Changed
+### Added
 
 - Relaxed type of `get_route_name` argument to `HTTPConnection`. This allows
   developers to use the `get_route_name` function for getting the name of
   websocket routes as well. Thanks to [@pajowu](https://github.com/pajowu) for
-  proposing and implementing this change in
+  proposing and implementing this feature in
   [#276](https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/276).
 
 ### Removed

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -39,7 +39,7 @@ Based on code from [elastic/apm-agent-python](https://github.com/elastic/apm-age
 
 from typing import List, Optional
 
-from starlette.requests import HttpConnection
+from starlette.requests import HTTPConnection
 from starlette.routing import Match, Mount, Route
 from starlette.types import Scope
 
@@ -66,7 +66,7 @@ def _get_route_name(
     return None
 
 
-def get_route_name(request: HttpConnection) -> Optional[str]:
+def get_route_name(request: HTTPConnection) -> Optional[str]:
     """Gets route name for given request taking mounts into account."""
 
     app = request.app

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -39,7 +39,7 @@ Based on code from [elastic/apm-agent-python](https://github.com/elastic/apm-age
 
 from typing import List, Optional
 
-from starlette.requests import Request
+from starlette.requests import HttpConnection
 from starlette.routing import Match, Mount, Route
 from starlette.types import Scope
 
@@ -66,7 +66,7 @@ def _get_route_name(
     return None
 
 
-def get_route_name(request: Request) -> Optional[str]:
+def get_route_name(request: HttpConnection) -> Optional[str]:
     """Gets route name for given request taking mounts into account."""
 
     app = request.app


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Some things to remember:

If you have a trivial fix or improvement, just do it.

If you plan something more involved, first raise an issue to discuss.

Should you wish to work on an issue, claim it first by commenting on it.

If the pull request is a work in progress, make use of the "Draft PR" feature.

Title your pull request following "Conventional Commits" styling.

If applicable, update CHANGELOG.md  according to "Keep a Changelog".

If applicable, update documentation (especially the README).

It's okay to not follow all of these recommendations.

-->

## What does this do?

This pr changes the type hint of `get_route_name` to accept a `HttpConnection` instead of a `Request`. All information `get_route_name` needs is already provided by the HttpConnection class, which Request is a subclass of. Changing this to HttpConnection allows also passing a WebSocket instead

## Why do we need it?

This allows developers to use the get_route_name function for getting the name of websocket routes as well, which can be very useful for creating custom metrics, e.g. https://github.com/bugbakery/transcribee/pull/389/files#diff-82bbfd4c38c16c9ba393ea259a91bd7a73077f6edc59368d492fe172ac933625R39

## Who is this for?

People who want to create own metrics for websocket routes.
