### PR TITLE
fix: duplicated prometheus timeseries error caused by inprogress requests

### DIFF
--- a/src/prometheus_fastapi_instrumentator/middleware.py
+++ b/src/prometheus_fastapi_instrumentator/middleware.py
@@ -112,12 +112,17 @@ class PrometheusInstrumentatorMiddleware:
                 if self.inprogress_labels
                 else ()
             )
-            self.inprogress = Gauge(
-                name=self.inprogress_name,
-                documentation="Number of HTTP requests in progress.",
-                labelnames=labels,
-                multiprocess_mode="livesum",
-            )
+            try:
+                self.inprogress = Gauge(
+                    name=self.inprogress_name,
+                    documentation="Number of HTTP requests in progress.",
+                    labelnames=labels,
+                    multiprocess_mode="livesum",
+                    registry=self.registry,
+                )
+            except ValueError as e:
+                if not metrics._is_duplicated_time_series(e):
+                    raise e
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":


### PR DESCRIPTION
## What does this do?

Handle value error when we set should_instrument_requests_inprogress and use the provided registry.

## Why do we need it?

To fix [> Add a description of the problem the feature is trying to solve.](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/269).

## Who is this for?

> Add information on what kind of persona the feature is for.

## Linked issues

[> Add a description of the problem the feature is trying to solve.](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/269)
