### PR TITLE
docs: Correct custom_labels usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ instrumentator = Instrumentator(
     excluded_handlers=[".*admin.*", "/metrics"],
     env_var_name="ENABLE_METRICS",
     inprogress_name="inprogress",
-    inprogress_labels=True,
-    custom_labels={"service": "example-label"}
+    inprogress_labels=True
 )
 ```
 
@@ -154,7 +153,12 @@ Closures come in handy here because it allows us to configure the functions
 within.
 
 ```python
-instrumentator.add(metrics.latency(buckets=(1, 2, 3,)))
+instrumentator.add(
+    metrics.latency(
+        buckets=(1, 2, 3,),
+        custom_labels={"region": "us-east-1"}
+    )
+)
 ```
 
 This simply adds the metric you also get in the fast track example with a


### PR DESCRIPTION
## What does this do?

> Corrects the example code in `README.md` regarding the usage of the `custom_labels` parameter. Specifically, it removes the incorrect example showing `custom_labels` being passed to the `Instrumentator` constructor and clarifies that it should be passed to individual metric functions via the `add()` method.

## Why do we need it?

> The previous example in the "Creating the Instrumentator" section of `README.md` incorrectly showed `custom_labels` as a parameter for the `Instrumentator` constructor. This does not align with the actual code implementation and could confuse users trying to add custom labels to their metrics. This PR fixes the documentation to accurately reflect the correct usage.

## Who is this for?

> This documentation fix is for all users of the `prometheus-fastapi-instrumentator` library, especially those looking to add custom labels to their Prometheus metrics.

## Linked issues

> N/A (If this addresses a specific issue, replace N/A with `Resolves #issue_number`)

## Reviewer notes

> This is a straightforward documentation fix to align the `README.md` examples with the actual code implementation for `custom_labels`. No code changes are involved.