### PR TITLE
Fix: Python3.8 type compatibility

### DIFF
--- a/src/prometheus_fastapi_instrumentator/metrics.py
+++ b/src/prometheus_fastapi_instrumentator/metrics.py
@@ -598,7 +598,7 @@ def requests(
     return None
 
 
-def _map_label_name_value(label_name: tuple) -> list[str]:
+def _map_label_name_value(label_name: Tuple) -> List[str]:
     attribute_names = []
     mapping = {
         "handler": "modified_handler",


### PR DESCRIPTION
## What does this do?

There's currently a breaking problem with python 3.8 support.

```
    from prometheus_fastapi_instrumentator import Instrumentator
  File "/pythonlibs/prometheus_fastapi_instrumentator/__init__.py", line 1, in <module>
    from .instrumentation import PrometheusFastApiInstrumentator
  File "/pythonlibs/prometheus_fastapi_instrumentator/instrumentation.py", line 21, in <module>
    from prometheus_fastapi_instrumentator import metrics
  File "/pythonlibs/prometheus_fastapi_instrumentator/metrics.py", line 601, in <module>
    def _map_label_name_value(label_name: tuple) -> list[str]:
TypeError: 'type' object is not subscriptable
Process SpawnProcess-4:
```

## Why do we need it?

To support python3.8 we need to use the `typing` module to support it. This is a trivial change of changing it to use the typing module.

## Who is this for?

Anyone who wants to use the library.

## Linked issues
Stems from these changes
https://github.com/trallnag/prometheus-fastapi-instrumentator/pull/326

 


