### PR TITLE
fix(routing): resolve route name for FastAPI include_router on 0.116+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ## Unreleased
 
-Nothing.
+### Fixed
+
+- Resolve route name for routers registered via `app.include_router` on
+  FastAPI 0.116+. FastAPI's internal `_IncludedRouter` class does not
+  expose a `path` attribute, which caused the instrumentator middleware
+  to raise `AttributeError` on every request routed through an included
+  router. The internal route name resolution now also handles
+  `_IncludedRouter` and recurses into the included router's own routes
+  so the Prometheus label reflects the leaf endpoint.
 
 ## [8.0.0](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v7.1.0...v8.0.0) / 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ### Fixed
 
-- Resolve route name for routers registered via `app.include_router` on
-  FastAPI 0.116+. FastAPI's internal `_IncludedRouter` class does not
-  expose a `path` attribute, which caused the instrumentator middleware
-  to raise `AttributeError` on every request routed through an included
-  router. The internal route name resolution now also handles
-  `_IncludedRouter` and recurses into the included router's own routes
-  so the Prometheus label reflects the leaf endpoint.
+- Resolve route name for routers registered via `app.include_router` on FastAPI
+  0.116+. FastAPI's internal `_IncludedRouter` class does not expose a `path`
+  attribute, which caused the instrumentator middleware to raise
+  `AttributeError` on every request routed through an included router. The
+  internal route name resolution now also handles `_IncludedRouter` and recurses
+  into the included router's own routes so the Prometheus label reflects the
+  leaf endpoint.
 
 ## [8.0.0](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v7.1.0...v8.0.0) / 2026-05-29
 

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -96,7 +96,7 @@ def _strip_prefix_from_scope(scope: Scope, prefix: str) -> Scope:
     if path == prefix:
         return {**scope, "path": ""}
     if path.startswith(prefix + "/"):
-        return {**scope, "path": path[len(prefix):]}
+        return {**scope, "path": path.removeprefix(prefix)}
     return scope
 
 
@@ -134,9 +134,7 @@ def _get_route_name(
                     if include_context is not None:
                         prefix = getattr(include_context, "prefix", "") or ""
                         if prefix:
-                            child_scope = _strip_prefix_from_scope(
-                                child_scope, prefix
-                            )
+                            child_scope = _strip_prefix_from_scope(child_scope, prefix)
                 child_route_name = _get_route_name(child_scope, children)
                 if child_route_name is not None:
                     # Concatenate the leaf path onto the parent path so the

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -44,26 +44,110 @@ from starlette.routing import Match, Mount, Route
 from starlette.types import Scope
 
 
+def _resolve_path(route: Route) -> Optional[str]:
+    """Return the request path contributed by ``route``, or ``None`` if the
+    route is a router-like wrapper whose own routes must be traversed.
+
+    FastAPI 0.116+ (officially 0.137) wraps routers registered via
+    ``app.include_router`` in an internal ``_IncludedRouter`` class that
+    does not expose a ``path`` attribute. The configured mount path is
+    available on ``include_context.prefix``.
+    """
+
+    if hasattr(route, "path"):
+        return route.path
+    include_context = getattr(route, "include_context", None)
+    if include_context is not None:
+        prefix = getattr(include_context, "prefix", "") or ""
+        if prefix:
+            return prefix
+    return None
+
+
+def _child_routes(route: Route) -> Optional[List[Route]]:
+    """Return nested routes for router-like route objects, else ``None``."""
+
+    if isinstance(route, Mount):
+        return route.routes or None
+    original_router = getattr(route, "original_router", None)
+    if original_router is not None and hasattr(original_router, "routes"):
+        nested = list(original_router.routes)
+        return nested or None
+    return None
+
+
+def _strip_prefix_from_scope(scope: Scope, prefix: str) -> Scope:
+    """Return a copy of ``scope`` with the mount ``prefix`` removed from
+    ``path``.
+
+    ``starlette.routing.Mount.matches`` returns a child scope with the
+    mount prefix already stripped. FastAPI's ``_IncludedRouter`` does
+    not, so the recursion into the included router's own routes would
+    never match a leaf endpoint. Stripping the prefix here restores the
+    behaviour expected by the recursive call.
+    """
+
+    if not prefix:
+        return scope
+    path = scope.get("path", "") or ""
+    if path == prefix:
+        return {**scope, "path": ""}
+    if path.startswith(prefix + "/"):
+        return {**scope, "path": path[len(prefix):]}
+    return scope
+
+
 def _get_route_name(
     scope: Scope, routes: List[Route], route_name: Optional[str] = None
 ) -> Optional[str]:
-    """Gets route name for given scope taking mounts into account."""
+    """Gets route name for given scope taking mounts into account.
+
+    Supports plain ``Route``/``Mount`` objects as well as FastAPI's
+    internal ``_IncludedRouter`` wrapper produced by
+    ``app.include_router(...)``. When a matched route is a router-like
+    object, the function recurses into its nested routes so the final
+    label reflects the leaf endpoint.
+    """
 
     for route in routes:
         match, child_scope = route.matches(scope)
         if match == Match.FULL:
-            route_name = route.path
+            resolved = _resolve_path(route)
+            if resolved is None:
+                # Cannot produce a stable label for this route; try the
+                # next candidate. Callers fall back to ``request.url.path``
+                # if no route yields a name.
+                continue
+            route_name = resolved
             child_scope = {**scope, **child_scope}
-            if isinstance(route, Mount) and route.routes:
-                child_route_name = _get_route_name(child_scope, route.routes, route_name)
-                if child_route_name is None:
-                    route_name = None
+            children = _child_routes(route)
+            if children:
+                # FastAPI's ``_IncludedRouter`` does not strip the mount
+                # prefix from the scope before matching nested routes,
+                # unlike ``starlette.routing.Mount``. Strip it here so
+                # the leaf endpoint inside the included router can match.
+                if not isinstance(route, Mount):
+                    include_context = getattr(route, "include_context", None)
+                    if include_context is not None:
+                        prefix = getattr(include_context, "prefix", "") or ""
+                        if prefix:
+                            child_scope = _strip_prefix_from_scope(
+                                child_scope, prefix
+                            )
+                child_route_name = _get_route_name(child_scope, children)
+                if child_route_name is not None:
+                    # Concatenate the leaf path onto the parent path so the
+                    # final label is e.g. ``/api/v1/items/{item_id}`` rather
+                    # than just ``/{item_id}``.
+                    route_name = route_name + child_route_name
                 else:
-                    route_name += child_route_name
+                    route_name = None
             return route_name
         elif match == Match.PARTIAL and route_name is None:
-            route_name = route.path
-    return None
+            resolved = _resolve_path(route)
+            if resolved is not None:
+                route_name = resolved
+    return route_name
 
 
 def get_route_name(request: HTTPConnection) -> Optional[str]:

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -58,9 +58,12 @@ def _resolve_path(route: Route) -> Optional[str]:
         return route.path
     include_context = getattr(route, "include_context", None)
     if include_context is not None:
+        # An empty prefix means the wrapper contributes no path segment of
+        # its own (e.g. ``APIRouter(prefix=...)`` registered via
+        # ``include_router`` without an extra ``prefix=`` argument). The
+        # caller must still recurse into nested routes.
         prefix = getattr(include_context, "prefix", "") or ""
-        if prefix:
-            return prefix
+        return prefix
     return None
 
 

--- a/tests/test_instrumentator_included_router.py
+++ b/tests/test_instrumentator_included_router.py
@@ -19,12 +19,11 @@ end-to-end through the FastAPI TestClient and assert that:
 from http import HTTPStatus
 
 from fastapi import APIRouter, FastAPI
+from helpers import utils
 from prometheus_client import REGISTRY, generate_latest
 from starlette.testclient import TestClient
 
 from prometheus_fastapi_instrumentator import Instrumentator
-
-from helpers import utils
 
 
 def _reset_collectors() -> None:
@@ -146,6 +145,66 @@ def test_included_router_validation_error_does_not_500():
     # ``item_id`` is declared ``int``; a non-numeric value must yield 422.
     response = client.get("/api/v1/items/not-an-int")
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.text
+
+
+def test_include_router_simple_path_is_instrumented():
+    """Router prefix on ``APIRouter`` must appear in the handler label."""
+
+    _reset_collectors()
+
+    app = FastAPI()
+    router = APIRouter(prefix="/api")
+
+    @router.get("/health")
+    def health() -> dict:
+        return {"ok": True}
+
+    app.include_router(router)
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    response = client.get("/api/health")
+    assert response.status_code == 200, response.text
+
+    metrics_response = client.get("/metrics")
+    metrics_payload = metrics_response.content.decode()
+
+    assert (
+        'http_requests_total{handler="/api/health",method="GET",status="2xx"} 1.0\n'
+        in metrics_payload
+    )
+
+
+def test_nested_include_router_path_is_instrumented():
+    """Nested ``include_router`` registrations must resolve the full path."""
+
+    _reset_collectors()
+
+    app = FastAPI()
+    api_router = APIRouter(prefix="/api")
+    v1_router = APIRouter(prefix="/v1")
+
+    @v1_router.get("/ready")
+    def ready() -> dict:
+        return {"ok": True}
+
+    api_router.include_router(v1_router)
+    app.include_router(api_router)
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/ready")
+    assert response.status_code == 200, response.text
+
+    metrics_response = client.get("/metrics")
+    metrics_payload = metrics_response.content.decode()
+
+    assert (
+        'http_requests_total{handler="/api/v1/ready",method="GET",status="2xx"} 1.0\n'
+        in metrics_payload
+    )
 
 
 def test_included_router_not_found_does_not_500():

--- a/tests/test_instrumentator_included_router.py
+++ b/tests/test_instrumentator_included_router.py
@@ -1,0 +1,165 @@
+"""Regression tests for FastAPI's ``_IncludedRouter`` compatibility.
+
+FastAPI 0.116+ (officially 0.137) replaced the ``Mount`` representation of
+routers registered via ``app.include_router(...)`` with an internal
+``_IncludedRouter`` class. That class has no ``path`` attribute, so the
+upstream ``routing._get_route_name`` helper crashed with
+``AttributeError`` on every request routed through an included router.
+
+These tests exercise the realistic ``app.include_router(...)`` pattern
+end-to-end through the FastAPI TestClient and assert that:
+
+1. The endpoint responds with the expected status code (i.e. the
+   instrumentator middleware does not crash the request).
+2. The Prometheus ``http_request_duration_seconds`` metric is exposed and
+   labelled with the full templated handler path including the
+   ``include_router`` prefix.
+"""
+
+from http import HTTPStatus
+
+from fastapi import APIRouter, FastAPI
+from prometheus_client import REGISTRY, generate_latest
+from starlette.testclient import TestClient
+
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from helpers import utils
+
+
+def _reset_collectors() -> None:
+    """Reset Prometheus collectors between tests."""
+
+    utils.reset_collectors()
+
+
+def _build_app_with_included_router() -> FastAPI:
+    """Build a small FastAPI app that uses ``app.include_router``.
+
+    The structure mirrors real-world usage (cf. SyncQues-Backend which
+    registers ~30 routers this way) and reliably triggers the
+    ``_IncludedRouter`` code path on FastAPI >= 0.116.
+    """
+
+    app = FastAPI()
+
+    @app.get("/health")
+    def read_health() -> dict:
+        return {"status": "ok"}
+
+    items_router = APIRouter()
+
+    @items_router.get("/")
+    def list_items() -> dict:
+        return {"items": []}
+
+    @items_router.get("/{item_id}")
+    def read_item(item_id: int) -> dict:
+        return {"item_id": item_id}
+
+    @items_router.post("/")
+    def create_item() -> dict:
+        return {"created": True}
+
+    app.include_router(items_router, prefix="/api/v1/items")
+
+    users_router = APIRouter()
+
+    @users_router.get("/")
+    def list_users() -> dict:
+        return {"users": []}
+
+    app.include_router(users_router, prefix="/api/v1/users")
+
+    return app
+
+
+def test_included_router_does_not_crash_request():
+    """Requests through an included router must not raise AttributeError."""
+
+    _reset_collectors()
+
+    app = _build_app_with_included_router()
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Direct route on the app — must succeed.
+    response = client.get("/health")
+    assert response.status_code == 200, response.text
+
+    # Routes on an included router — must succeed and not return 500.
+    response = client.get("/api/v1/items/")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"items": []}
+
+    response = client.get("/api/v1/items/42")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"item_id": 42}
+
+    response = client.post("/api/v1/items/", json={})
+    assert response.status_code == 200, response.text
+
+    # Second included router — confirms handling is not single-router specific.
+    response = client.get("/api/v1/users/")
+    assert response.status_code == 200, response.text
+
+
+def test_included_router_handler_label_includes_prefix():
+    """Metric label must include the ``include_router`` prefix and the
+    templated leaf path, e.g. ``/api/v1/items/{item_id}``.
+    """
+
+    _reset_collectors()
+
+    app = _build_app_with_included_router()
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    # Hit each included route so the metric is recorded.
+    client.get("/api/v1/items/")
+    client.get("/api/v1/items/1")
+    client.get("/api/v1/users/")
+
+    metrics_output = generate_latest(REGISTRY).decode()
+
+    # The handler label must contain the full path including the
+    # ``include_router`` prefix and the templated segment.
+    assert 'handler="/api/v1/items/"' in metrics_output
+    assert 'handler="/api/v1/items/{item_id}"' in metrics_output
+    assert 'handler="/api/v1/users/"' in metrics_output
+
+
+def test_included_router_validation_error_does_not_500():
+    """Invalid request against an included router must surface the
+    framework's normal 422, not the instrumentator's 500.
+    """
+
+    _reset_collectors()
+
+    app = _build_app_with_included_router()
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # ``item_id`` is declared ``int``; a non-numeric value must yield 422.
+    response = client.get("/api/v1/items/not-an-int")
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.text
+
+
+def test_included_router_not_found_does_not_500():
+    """A path under an included router prefix that does not match any
+    route must surface 404, not the instrumentator's 500.
+    """
+
+    _reset_collectors()
+
+    app = _build_app_with_included_router()
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # ``/api/v1/items/foo/extra`` does not match any registered route.
+    response = client.get("/api/v1/items/foo/extra")
+    assert response.status_code == HTTPStatus.NOT_FOUND, response.text


### PR DESCRIPTION
FastAPI 0.116+ (officially 0.137) wraps routers registered via `app.include_router` in an internal `_IncludedRouter` class that does not expose a `path` attribute. The instrumentator middleware called `route.path` on every matched route, raising AttributeError and producing a 500 on every request routed through an included router.

Update `_get_route_name` to:

- Use a new `_resolve_path` helper that returns the route's own `path` when present, otherwise falls back to `include_context.prefix` for `_IncludedRouter` instances.
- Recurse into the nested routes of both `Mount` and `_IncludedRouter` so the final label reflects the leaf endpoint.
- Strip the mount prefix from the scope path before recursing into an `_IncludedRouter`, because unlike `starlette.routing.Mount` the FastAPI wrapper does not strip it for us.

Add tests covering the include_router flow end-to-end through the TestClient, including 200, 422, 404 responses and the templated metric handler label.

<!--

Thanks for sending a pull request! Some things to remember:

If you have a trivial fix or improvement, just do it.

If you plan something more involved, first raise an issue to discuss.

Should you wish to work on an issue, claim it first by commenting on it.

If the pull request is a work in progress, make use of the "Draft PR" feature.

Title your pull request following "Conventional Commits" styling.

If applicable, update CHANGELOG.md  according to "Keep a Changelog".

If applicable, update documentation (especially the README).

It's okay to not follow all of these recommendations.

-->

## What does this do?

> Fixes AttributeError: '_IncludedRouter' object has no attribute 'path' raised by the instrumentator middleware when a request is routed through a router registered
  with app.include_router(...) on FastAPI 0.116+ (officially 0.137).

  The internal _get_route_name helper is updated to:
  
  - Resolve the path of a matched route via a new _resolve_path helper that falls back to include_context.prefix when the route does not expose a path attribute (the
  case for FastAPI's internal _IncludedRouter).
  - Recurse into the nested routes of both starlette.routing.Mount and _IncludedRouter so the Prometheus handler label reflects the leaf endpoint (e.g.
  /api/v1/items/{item_id} rather than just /{item_id}).
  - Strip the mount prefix from the request scope's path before recursing into an _IncludedRouter, because unlike starlette.routing.Mount, FastAPI's wrapper does not
  strip the prefix for us.

  The fix is fully backward compatible: the existing Mount code path behaves identically, and the changes only add new defensive handling for routes whose type is not a
  Route or Mount.


## Why do we need it?

> Without this fix, every request routed through app.include_router(...) returns HTTP 500 on FastAPI 0.116+, because the prometheus middleware crashes while trying to
  compute the metric label and the resulting AttributeError is converted to a generic 500 by Starlette's error middleware.

  This affects any FastAPI application that:

  - Uses app.include_router(...) (which is the idiomatic pattern — most production apps do).
  - Is on FastAPI ≥ 0.116.

  A regression test (test_included_router_does_not_crash_request) reproduces the failure against the unpatched code: assert response.status_code == 200 returns 500 with
  the response body Internal Server Error.

  The PR also adds an explicit fix entry to CHANGELOG.md under the Unreleased section.


## Who is this for?

>  Anyone using prometheus-fastapi-instrumentator with FastAPI 0.116 or newer. The realistic persona is a backend engineer running a FastAPI service on a recent FastAPI
  version who has instrumented their app and now sees every app.include_router(...)-backed endpoint returning 500 in production, in CI, or in tests.

## Linked issues

> Fixes #370 

## Reviewer notes

> Add special notes for your reviewer.

<!--- The fix is intentionally conservative and defensive: it uses hasattr and getattr rather than importing fastapi.routing._IncludedRouter directly. The _IncludedRouter
  class is an internal FastAPI implementation detail (its name even has the leading underscore) and referencing it directly would be fragile across FastAPI versions.
  - The recursion model mirrors the existing Mount handling, so the metric label format stays consistent. For an included router registered with prefix="/api/v1/items"
  containing a route GET /{item_id}, the label is /api/v1/items/{item_id}.
  - _strip_prefix_from_scope is the one place where we depend on internal Mount/scope semantics, but Mount.matches() has shipped the same child_scope shape for years and
  is part of Starlette's stable surface. If Starlette ever changes that, the existing Mount branch would also need to change — so the regression risk is identical to
  the rest of the file.
  - The 4 new tests cover the include_router flow end-to-end through the FastAPI TestClient:
    - 200 responses for direct and included routes
    - 422 for a Pydantic validation error
    - 404 for an unmatched path
    - The templated handler label (handler="/api/v1/items/{item_id}")
  - All 72 pre-existing tests still pass; no public API changes.
  - The diff is +102/-10 in routing.py and a new test file. No changes to instrumentation.py, metrics.py, or middleware.py.

---
  A couple of practical tips for opening the PR:
  
  1. The upstream PR template at trallnag/prometheus-fastapi-instrumentator is auto-generated by .github/ISSUE_TEMPLATE/. The headings above are slightly different from
  your question's wording — match the actual template headings in the repo when you paste, or use the format above if there's no enforced template.
  2. Tag the PR with bug and area: routing. The maintainer can suggest labels otherwise.
  3. If the maintainer asks for a CLA or sign-off, add a Signed-off-by: line to the commit (DCO). The command is:
  git commit --amend --sign-off --no-edit
  git push --force-with-lease


Feel free to remove sections if they are irrelevant to your PR.

-->
