### PR TITLE
fix: handle routes without path attribute for starlette>=1.3.0 compat…

### DIFF
--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -52,7 +52,7 @@ def _get_route_name(
     for route in routes:
         match, child_scope = route.matches(scope)
         if match == Match.FULL:
-            route_name = route.path
+            route_name = getattr(route, "path", "")
             child_scope = {**scope, **child_scope}
             if isinstance(route, Mount) and route.routes:
                 child_route_name = _get_route_name(child_scope, route.routes, route_name)
@@ -62,7 +62,7 @@ def _get_route_name(
                     route_name += child_route_name
             return route_name
         elif match == Match.PARTIAL and route_name is None:
-            route_name = route.path
+            route_name = getattr(route, "path", "")
     return None
 
 


### PR DESCRIPTION
## What does this do?

  Fixes AttributeError: '_IncludedRouter' object has no attribute 'path' in routing.py by using getattr(route, "path", "")
  instead of route.path directly.

 ## Why do we need it?

  starlette 1.3.0 introduced _IncludedRouter objects that don't have a path attribute. Any FastAPI application using
  prometheus-fastapi-instrumentator==8.0.0 with starlette>=1.3.0 (pulled in by fastapi>=0.137.0) crashes on startup with:

  AttributeError: '_IncludedRouter' object has no attribute 'path'

 ## Who is this for?

  Anyone using FastAPI >=0.137.0 or Starlette >=1.3.0 with this library.
## Reviewer notes
  Two occurrences fixed at lines 55 and 65 — both FULL and PARTIAL match branches had the same issue.