### PR TITLE
fix: Resolve HTTP 500 from _IncludedRouter on FastAPI >= 0.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
 ## Unreleased
 
-Nothing.
+### Fixed
+
+- Resolve `AttributeError: '_IncludedRouter' object has no attribute 'path'`
+  that caused requests to return HTTP 500 with FastAPI >= 0.137. FastAPI now
+  stores routers added via `include_router(...)` as `_IncludedRouter` wrappers
+  (which have no `path`) in `app.routes`, so the route-name resolver raised
+  when reading `route.path` -- on full matches *and* partial matches such as
+  405 method mismatches. Route-name resolution now recovers the full, prefixed
+  name from the wrapper's `effective_route_contexts()` (handling included
+  `APIRoute`, mounted sub-apps and websocket routes), and is guarded so it
+  degrades to no route label rather than raising. Fixes
+  [#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370).
 
 ## [8.0.0](https://github.com/trallnag/prometheus-fastapi-instrumentator/compare/v7.1.0...v8.0.0) / 2026-05-29
 

--- a/src/prometheus_fastapi_instrumentator/routing.py
+++ b/src/prometheus_fastapi_instrumentator/routing.py
@@ -37,32 +37,82 @@ is contained in a dedicated module.
 Based on code from [elastic/apm-agent-python](https://github.com/elastic/apm-agent-python/blob/527f62c0c50842f94ef90fda079853372539319a/elasticapm/contrib/starlette/__init__.py).
 """
 
-from typing import List, Optional
+import logging
+from typing import Any, List, Optional
 
 from starlette.requests import HTTPConnection
-from starlette.routing import Match, Mount, Route
+from starlette.routing import BaseRoute, Match, Mount
 from starlette.types import Scope
+
+logger = logging.getLogger(__name__)
+
+
+def _effective_route_path(ctx: Any, scope: Scope, child_scope: Scope) -> Optional[str]:
+    """Resolve the full, prefixed path for a matched FastAPI
+    ``_EffectiveRouteContext``.
+
+    For ``APIRoute`` contexts the prefixed path is on ``ctx.path`` (and
+    ``ctx.starlette_route`` is ``None``). For ``Mount`` and websocket contexts
+    ``ctx.path`` is ``""`` and the prefixed path is carried by
+    ``ctx.starlette_route`` instead; mounts are recursed into so the mounted
+    sub-route name is appended, matching the handling of top-level mounts.
+    """
+    underlying = getattr(ctx, "starlette_route", None)
+    if underlying is None:
+        return getattr(ctx, "path", None)
+    if isinstance(underlying, Mount) and underlying.routes:
+        child_route_name = _get_route_name(
+            {**scope, **child_scope}, underlying.routes, underlying.path
+        )
+        if child_route_name is None:
+            return None
+        return underlying.path + child_route_name
+    return getattr(underlying, "path", None)
 
 
 def _get_route_name(
-    scope: Scope, routes: List[Route], route_name: Optional[str] = None
+    scope: Scope, routes: List[BaseRoute], route_name: Optional[str] = None
 ) -> Optional[str]:
-    """Gets route name for given scope taking mounts into account."""
+    """Gets route name for given scope, taking mounts and included routers
+    into account."""
 
     for route in routes:
+        # FastAPI (>= 0.137) wraps every ``include_router(...)`` in a private
+        # ``_IncludedRouter`` -- a ``BaseRoute`` *without* a ``path``, so the
+        # generic ``route.path`` accesses below would raise ``AttributeError``
+        # (#370) on both full and partial (e.g. 405) matches. Resolve it via
+        # its ``effective_route_contexts()``, whose contexts expose the fully
+        # prefixed path. Detected by duck typing so this library still works
+        # with plain Starlette (which never has it); guarded broadly so that a
+        # future FastAPI internals change degrades to no route label rather
+        # than turning every request into a 500.
+        effective_contexts = getattr(route, "effective_route_contexts", None)
+        if callable(effective_contexts):
+            try:
+                for ctx in effective_contexts():
+                    ctx_match, ctx_child_scope = ctx.matches(scope)
+                    if ctx_match == Match.FULL:
+                        return _effective_route_path(ctx, scope, ctx_child_scope)
+            except Exception:
+                logger.debug(
+                    "Could not resolve route name from an included router; "
+                    "falling back to no route label.",
+                    exc_info=True,
+                )
+            continue
+
         match, child_scope = route.matches(scope)
         if match == Match.FULL:
-            route_name = route.path
-            child_scope = {**scope, **child_scope}
             if isinstance(route, Mount) and route.routes:
-                child_route_name = _get_route_name(child_scope, route.routes, route_name)
+                child_route_name = _get_route_name(
+                    {**scope, **child_scope}, route.routes, route.path
+                )
                 if child_route_name is None:
-                    route_name = None
-                else:
-                    route_name += child_route_name
-            return route_name
+                    return None
+                return route.path + child_route_name
+            return getattr(route, "path", None)
         elif match == Match.PARTIAL and route_name is None:
-            route_name = route.path
+            route_name = getattr(route, "path", None)
     return None
 
 

--- a/tests/test_instrumentator_included_router.py
+++ b/tests/test_instrumentator_included_router.py
@@ -1,0 +1,179 @@
+from fastapi import APIRouter, FastAPI
+from helpers import utils
+from prometheus_client import Counter
+from starlette.routing import Mount
+from starlette.testclient import TestClient
+
+from prometheus_fastapi_instrumentator import Instrumentator, metrics
+from prometheus_fastapi_instrumentator.routing import _get_route_name
+
+
+def _handler_metric() -> Counter:
+    return Counter("test", "Test.", ("modified_handler", "handler"))
+
+
+def _add_handler_instrumentation(instrumentator: Instrumentator, metric: Counter):
+    def instrumentation(info: metrics.Info) -> None:
+        metric.labels(
+            modified_handler=info.modified_handler,
+            handler=str(info.request.url),
+        ).inc()
+
+    instrumentator.add(instrumentation)
+
+
+def test_included_router_resolves_prefixed_handler():
+    """Routes added via ``include_router`` must not 500 and must report their
+    full, prefixed path as the handler label.
+
+    Regression test for #370. Since FastAPI 0.137 ``include_router`` stores a
+    ``_IncludedRouter`` (a ``BaseRoute`` without a ``path``) in ``app.routes``,
+    which made route-name resolution raise ``AttributeError`` -> HTTP 500.
+    Exercising the regression requires FastAPI >= 0.137; on earlier versions
+    the assertions still hold because included routes were copied with their
+    full path.
+    """
+    utils.reset_collectors()
+
+    app = FastAPI()
+
+    router = APIRouter()
+
+    @router.get("/models")
+    def models():
+        return {"message": "from included router"}
+
+    app.include_router(router, prefix="/v1")
+
+    nested_inner = APIRouter()
+
+    @nested_inner.get("/ping")
+    def ping():
+        return {"message": "from nested included router"}
+
+    nested_outer = APIRouter()
+    nested_outer.include_router(nested_inner, prefix="/inner")
+    app.include_router(nested_outer, prefix="/api")
+
+    metric = _handler_metric()
+    instrumentator = Instrumentator()
+    _add_handler_instrumentation(instrumentator, metric)
+    instrumentator.instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    assert client.get("/v1/models").status_code == 200
+    assert client.get("/api/inner/ping").status_code == 200
+
+    response = client.get("/metrics").content.decode()
+
+    want = '{handler="http://testserver/v1/models",modified_handler="/v1/models"} 1.0\n'
+    assert want in response
+
+    want = '{handler="http://testserver/api/inner/ping",modified_handler="/api/inner/ping"} 1.0\n'
+    assert want in response
+
+
+def test_included_router_without_prefix():
+    """An included router without a prefix resolves to the route's own path."""
+    utils.reset_collectors()
+
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/widget")
+    def widget():
+        return {"message": "ok"}
+
+    app.include_router(router)
+
+    metric = _handler_metric()
+    instrumentator = Instrumentator()
+    _add_handler_instrumentation(instrumentator, metric)
+    instrumentator.instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    assert client.get("/widget").status_code == 200
+
+    response = client.get("/metrics").content.decode()
+    want = '{handler="http://testserver/widget",modified_handler="/widget"} 1.0\n'
+    assert want in response
+
+
+def test_included_router_method_mismatch_does_not_crash():
+    """A 405 on an included route (path matches, method does not) must not
+    crash route-name resolution.
+
+    Regression for #370: a method mismatch yields ``Match.PARTIAL``, which used
+    to hit the same missing-``path`` access on the ``_IncludedRouter`` and turn
+    the 405 into a 500.
+    """
+    utils.reset_collectors()
+
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/models")
+    def models():
+        return {"message": "ok"}
+
+    app.include_router(router, prefix="/v1")
+
+    Instrumentator().instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    assert client.post("/v1/models").status_code == 405
+
+
+def test_mount_inside_included_router():
+    """A Starlette ``Mount`` nested inside an included router resolves to its
+    full, prefixed path (its effective context exposes the path via
+    ``starlette_route``, not ``ctx.path``)."""
+    utils.reset_collectors()
+
+    app = FastAPI()
+
+    subapp = FastAPI()
+
+    @subapp.get("/deep")
+    def deep():
+        return {"message": "ok"}
+
+    router = APIRouter()
+    router.routes.append(Mount("/mnt", app=subapp))
+    app.include_router(router, prefix="/m")
+
+    metric = _handler_metric()
+    instrumentator = Instrumentator()
+    _add_handler_instrumentation(instrumentator, metric)
+    instrumentator.instrument(app).expose(app)
+
+    client = TestClient(app)
+
+    assert client.get("/m/mnt/deep").status_code == 200
+
+    response = client.get("/metrics").content.decode()
+    want = '{handler="http://testserver/m/mnt/deep",modified_handler="/m/mnt/deep"} 1.0\n'
+    assert want in response
+
+
+def test_websocket_under_included_router_resolves_path():
+    """WebSocket routes under an included router resolve to the full prefixed
+    path. Their effective context stores the path on ``starlette_route`` (its
+    ``ctx.path`` is empty), so this guards that extraction path directly."""
+    utils.reset_collectors()
+
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.websocket("/ws")
+    async def ws(websocket):
+        await websocket.accept()
+        await websocket.close()
+
+    app.include_router(router, prefix="/v1")
+
+    scope = {"type": "websocket", "path": "/v1/ws", "headers": []}
+    assert _get_route_name(scope, app.routes) == "/v1/ws"


### PR DESCRIPTION
## Summary

On FastAPI **>= 0.137**, requests through an instrumented app return **HTTP 500** with:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

This fixes the route-name resolver to handle FastAPI's new `_IncludedRouter`
route objects. Fixes #370. (Also surfaced downstream in vLLM:
vllm-project/vllm#45596, vllm-project/vllm#45597.)

## Root cause

FastAPI 0.137 (fastapi/fastapi#15745) changed `include_router(...)` to store a
private `_IncludedRouter` wrapper in `app.routes` instead of copying the child
routes. `_IncludedRouter` is a `BaseRoute` **without** a `.path` attribute.
`routing._get_route_name()` walks `app.routes` and read `route.path`
unconditionally, so it raised `AttributeError` for any app that uses
`include_router()` — i.e. essentially every FastAPI app — on both full matches
and partial matches (e.g. a 405, which turned into a 500).

## Fix

`_get_route_name()` now detects an included router by duck-typing its
`effective_route_contexts()` method (so the library keeps working with plain
Starlette, which never has it) and resolves the name from those contexts, which
expose the fully-prefixed path:

- included `APIRoute` → the context's `path`;
- mounted sub-apps and websocket routes under an included router →
  `ctx.starlette_route.path` (their `ctx.path` is `""`), with mounts recursed
  into so the sub-route name is appended (mirrors top-level `Mount` handling);
- the lookup is guarded and `debug`-logged, so a future FastAPI internals
  change degrades to an unlabeled metric rather than turning every request into
  a 500;
- `.path` reads on plain routes are now guarded too, so non-routable entries
  (e.g. `Host`) no longer raise.

Behavior on FastAPI < 0.137 is unchanged — there `include_router` still copies
routes, so the new branch is never taken.

## Tests

`tests/test_instrumentator_included_router.py` adds coverage for: prefixed,
nested, and unprefixed includes; a 405 method-mismatch (no longer 500s); a
`Mount` inside an included router; and websocket route-name resolution. The
assertions also hold on FastAPI < 0.137.

## ⚠️ CI note (why this slipped through)

The dev dependency pins `fastapi = "^0.136.3"` (i.e. `< 0.137`), so CI never
constructs an `_IncludedRouter` today — which is exactly why #370 wasn't caught,
and it means the new tests **pass but don't *exercise* the regression** on CI
as-is.

The right remedy is to run the suite against **both** a `<0.137` and a `>=0.137`
FastAPI (a small test-matrix change) — not just bumping the pin, since a bare
bump would drop coverage of the `<0.137` path this fix must keep supporting.
I've kept that out of this PR to keep it focused, and because the matrix shape
is your call. Happy to add it here as a separate commit or as a follow-up —
whichever you prefer.

## Validation

Locally on FastAPI 0.137.1 / Starlette 1.3.1: the new tests plus the full
existing suite pass (`80 passed, 4 skipped`), and `black`, `isort`, `flake8`,
and `mypy` are clean.
